### PR TITLE
ci: add compile workflow and README badge

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,17 @@
+name: compile
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ devops ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Show compiler version
+        run: g++ --version
+      - name: Compile
+        run: g++ -std=c++17 main.cpp -o autovalidate

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # autovalidate
 
+[![compile](https://github.com/BapePreme2/autovalidate/actions/workflows/compile.yml/badge.svg)](https://github.com/BapePreme2/autovalidate/actions/workflows/compile.yml)
+
 I like that app too!
 
 This repo is compatible with the [cpp-container docker container](https://github.com/ChicoState/cpp-container).


### PR DESCRIPTION
Fixes ChicoState/autovalidate#2

- Adds .github/workflows/compile.yml (name: compile)
- Runs: g++ -std=c++17 main.cpp
- Adds README badge for the compile workflow
