### PR TITLE
Implemented compilation CI workflow; closes #2

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,22 @@
+name: compile
+on:
+  push:
+    branches: [ devops ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -f build-essential g++ cmake
+  build:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build project
+        run: g++ -std=c++17 main.cpp


### PR DESCRIPTION
Created a CI workflow called compile so that it builds the application in an Ubuntu environment with the command:
g++ -std=c++17 main.cpp

It is triggered to run whenever:
a pull request has been made for the main branch
any new commits have been pushed to a branch called devops