### PR TITLE
fix: terminate immediately on "nothing"

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -18,19 +18,22 @@ int main(){
   int pick;
 
   srand(time(0));
-  pick = rand() % VALIDATION.size();
+
   cout << "What are you listening to?\n";
-  getline(cin,input);
-  transform(input.begin(), input.end(), input.begin(), [](unsigned char c){ return std::tolower(c); });
+  if (!getline(cin, input)) return 0;
+
+  if (input == "nothing") return 0;               
+
+  pick = rand() % VALIDATION.size();
   cout << VALIDATION[pick] << "! Let's listen to more\n";
 
-  do{
+  while (true) {
     cout << "What's next?\n";
-    getline(cin,input);
-    transform(input.begin(), input.end(), input.begin(), [](unsigned char c){ return std::tolower(c); });
+    if (!getline(cin, input)) break;
+    if (input == "nothing") break;                
     pick = rand() % VALIDATION.size();
     cout << VALIDATION[pick] << "!\n";
-  }while( input != "nothing" );
+  }
 
   return 0;
 }


### PR DESCRIPTION
Fixes ChicoState/autovalidate#1

- If the first input is `nothing`, exit without printing a validation line